### PR TITLE
remove .underscore on class name

### DIFF
--- a/lib/party_bus/models/concerns/publishable.rb
+++ b/lib/party_bus/models/concerns/publishable.rb
@@ -42,7 +42,7 @@ module Publishable
     # This method is overrideable in case the resource name in party bus differs
     # from the model name. By default we just use the model name.
     def pb_resource_name
-      self.class.to_s.underscore
+      self.class.to_s
     end
 
     def pb_serialize(action = nil, include_changes: true)

--- a/lib/party_bus/version.rb
+++ b/lib/party_bus/version.rb
@@ -1,3 +1,3 @@
 module PartyBus
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Removes the underscore on model name so that we pass up pascal case model names for ruby models.